### PR TITLE
Fix setting of FPS and unload subtitle if FPS not set

### DIFF
--- a/qml/pages/FPSDialog.qml
+++ b/qml/pages/FPSDialog.qml
@@ -2,7 +2,8 @@ import QtQuick 2.2
 import Sailfish.Silica 1.0
 
 Dialog {
-    property double fps
+    property double fps: 0
+    property bool selected: false
     allowedOrientations: Orientation.All
 
     function itemTextToIndex(text) {
@@ -26,6 +27,8 @@ Dialog {
         return 0
     }
 
+    canAccept: selected === true
+
     Column {
         width: parent.width
 
@@ -37,6 +40,7 @@ Dialog {
             label: qsTr("Select subtitle FPS")
             value: fps > 0 ? fps.toString() : "23.976"
             currentIndex: itemTextToIndex(fps.toString())
+            onEntered: selected = true
 
             menu: ContextMenu {
                 id: menu
@@ -57,7 +61,7 @@ Dialog {
     }
 
     onDone: {
-        if (result == DialogResult.Accepted)
+        if (result == DialogResult.Accepted && optionBox.currentIndex > 0)
             fps = parseFloat(optionBox.currentItem.text)
         else
             fps = 0

--- a/qml/pages/SubtitleView.qml
+++ b/qml/pages/SubtitleView.qml
@@ -245,12 +245,14 @@ Page {
                     subSailMain.playing = playstate
             })
             dialog.onRejected.connect(function() {
-                clearSubtitles()
                 if (fps === 0) {
                     loaded = false
                     subtitleFilePath = ""
-                    totalTime = 0
+                    showFPSSelector = false
+                    SubtitleEngine.unloadSubtitle();
                 }
+
+                clearSubtitles()
             })
         })
     }
@@ -260,6 +262,7 @@ Page {
         currentPlaying = subSailMain.playing
         subSailMain.playing = false
         subtitleFilePath = ""
+        fps = 0.0
 
         var pickerObj = pageStack.animatorPush("Sailfish.Pickers.FilePickerPage", {
             nameFilters: ["*.srt", "*.sub"],

--- a/qml/pages/SubtitleView.qml
+++ b/qml/pages/SubtitleView.qml
@@ -246,6 +246,11 @@ Page {
             })
             dialog.onRejected.connect(function() {
                 clearSubtitles()
+                if (fps === 0) {
+                    loaded = false
+                    subtitleFilePath = ""
+                    totalTime = 0
+                }
             })
         })
     }
@@ -310,28 +315,33 @@ Page {
         clearSubtitles()
     }
 
+    function errorNotifyLoadFailure(message)
+    {
+        errorNotify(message, qsTr("Subtitle load failure"))
+    }
+
     function checkSubtitleLoadResult()
     {
         switch (loadStatus) {
         case SubtitleEngine.SUBTITLE_LOAD_STATUS_FAILURE:
         case 6:
-            errorNotify(qsTr("Failed to load file"), qsTr("Subtitle load failure"))
+            errorNotifyLoadFailure(qsTr("Failed to load file"))
             break
         case SubtitleEngine.SUBTITLE_LOAD_STATUS_PARSE_FAILURE:
         case 5:
-            errorNotify(qsTr("Failed to parse file"), qsTr("Subtitle load failure"))
+            errorNotifyLoadFailure(qsTr("Failed to parse file"))
             break
         case SubtitleEngine.SUBTITLE_LOAD_STATUS_NOT_SUPPORTED:
         case 4:
-            errorNotify(qsTr("Subtitle type not supported"), qsTr("Subtitle load failure"))
+            errorNotifyLoadFailure(qsTr("Subtitle type not supported"))
             break
         case SubtitleEngine.SUBTITLE_LOAD_STATUS_ACCESS_DENIED:
         case 3:
-            errorNotify(qsTr("File access denied"), qsTr("Subtitle load failure"))
+            errorNotifyLoadFailure(qsTr("File access denied"))
             break
         case SubtitleEngine.SUBTITLE_LOAD_STATUS_FILE_NOT_FOUND:
         case 2:
-            errorNotify(qsTr("File not found"), qsTr("Subtitle load failure"))
+            errorNotifyLoadFailure(qsTr("File not found"))
             break
         case SubtitleEngine.SUBTITLE_LOAD_STATUS_OK_NEED_FPS:
         case 1:
@@ -346,7 +356,7 @@ Page {
             break
         default:
             console.log("subtitle load status out of bounds:", loadStatus)
-            errorNotify(qsTr("Unknown error"), qsTr("Subtitle load failure"))
+            errorNotifyLoadFailure(qsTr("Unknown error"))
             break
         }
     }

--- a/src/subtitleengine.cpp
+++ b/src/subtitleengine.cpp
@@ -123,6 +123,12 @@ SubtitleEngine::SubtitleLoadStatus SubtitleEngine::loadSubtitle(QString file)
     return SUBTITLE_LOAD_STATUS_OK;
 }
 
+void SubtitleEngine::unloadSubtitle()
+{
+    qDebug() << "unload subtitle and reset";
+    freeSubtitles();
+}
+
 void SubtitleEngine::updateFps(double fps)
 {
     Subtitle *subtitle = nullptr;

--- a/src/subtitleengine.h
+++ b/src/subtitleengine.h
@@ -43,6 +43,7 @@ public:
     Q_ENUM(SubtitleLoadStatus);
 
     Q_INVOKABLE SubtitleEngine::SubtitleLoadStatus loadSubtitle(QString str);
+    Q_INVOKABLE void unloadSubtitle();
     Q_INVOKABLE void updateFps(double fps);
     Q_INVOKABLE void increaseTime(int time);
     Q_INVOKABLE void setTime(int time);

--- a/translations/harbour-subsail.ts
+++ b/translations/harbour-subsail.ts
@@ -62,7 +62,7 @@ Automatic resume of playback after returning to main view can be changed in sett
 <context>
     <name>FPSDialog</name>
     <message>
-        <location filename="../qml/pages/FPSDialog.qml" line="37"/>
+        <location filename="../qml/pages/FPSDialog.qml" line="40"/>
         <source>Select subtitle FPS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -161,97 +161,92 @@ Automatic resume of playback after returning to main view can be changed in sett
 <context>
     <name>SubtitleView</name>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="318"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="328"/>
         <source>Failed to load file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="318"/>
-        <location filename="../qml/pages/SubtitleView.qml" line="322"/>
-        <location filename="../qml/pages/SubtitleView.qml" line="326"/>
-        <location filename="../qml/pages/SubtitleView.qml" line="330"/>
-        <location filename="../qml/pages/SubtitleView.qml" line="334"/>
-        <location filename="../qml/pages/SubtitleView.qml" line="349"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="320"/>
         <source>Subtitle load failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="322"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="332"/>
         <source>Failed to parse file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="326"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="336"/>
         <source>Subtitle type not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="330"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="340"/>
         <source>File access denied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="334"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="344"/>
         <source>File not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="349"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="359"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="394"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="404"/>
         <source>FPS change timer overflow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="394"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="404"/>
         <source>Time reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="431"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="441"/>
         <source>Failed to change fallback codec to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="431"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="441"/>
         <source>Codec empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="434"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="444"/>
         <source>Failed to change fallback codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="434"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="444"/>
         <source>Invalid codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="477"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="487"/>
         <source>Failed to load subtitle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="492"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="502"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="497"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="507"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="502"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="512"/>
         <source>Select Subtitle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="506"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="516"/>
         <source>Select FPS</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-subsail.ts
+++ b/translations/harbour-subsail.ts
@@ -161,92 +161,92 @@ Automatic resume of playback after returning to main view can be changed in sett
 <context>
     <name>SubtitleView</name>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="328"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="331"/>
         <source>Failed to load file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="320"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="323"/>
         <source>Subtitle load failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="332"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="335"/>
         <source>Failed to parse file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="336"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="339"/>
         <source>Subtitle type not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="340"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="343"/>
         <source>File access denied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="344"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="347"/>
         <source>File not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="359"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="362"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="404"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="407"/>
         <source>FPS change timer overflow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="404"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="407"/>
         <source>Time reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="441"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="444"/>
         <source>Failed to change fallback codec to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="441"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="444"/>
         <source>Codec empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="444"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="447"/>
         <source>Failed to change fallback codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="444"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="447"/>
         <source>Invalid codec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="487"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="490"/>
         <source>Failed to load subtitle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="502"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="505"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="507"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="510"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="512"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="515"/>
         <source>Select Subtitle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SubtitleView.qml" line="516"/>
+        <location filename="../qml/pages/SubtitleView.qml" line="519"/>
         <source>Select FPS</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Improve the FPS selection dialog to allow "accept" only when the selector is used.

Add unloading of subtitle if FPS setting is declined.

Cleanup some error notify stuff.