### PR TITLE
engine: optimize time setting and fix index use

### DIFF
--- a/src/subtitleengine.h
+++ b/src/subtitleengine.h
@@ -61,6 +61,7 @@ private:
     void setupSubtitles();
     void resetEngine();
     Subtitle *getSubtitleNow();
+    int findPosition(int time, int min, int max);
 
     static SubtitleEngine* iEngine;
 


### PR DESCRIPTION
Implement binary search to get the approximate location for the subtitle, use position - 1 just in case to avoid cases with time overlapping with start/end times.

Fix index use, subtitles start from 1.